### PR TITLE
Set Jar output to use zip64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ dependencies {
 }
 
 jar {
+    zip64 true
     manifest {
         attributes([
             "Specification-Title": "gti",


### PR DESCRIPTION
Fixes `archive contains more than 65535 entries` on jar build after runData task