### PR TITLE
Remove OneProbe Fabric bits from build

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -56,7 +56,6 @@ dependencies{
         transitive = false
     }
     modRuntimeOnly("dev.latvian.mods:kubejs-fabric:${rootProject.kubejs_version}")
-    //modRuntimeOnly("curse.maven:the-one-probe-fabric-581847:${rootProject.top_fabric_file}")
 }
 
 architectury {

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,5 +32,4 @@ antimatter_archive_base_name=AntimatterAPI
 tesseract_mod_version=0.1
 tesseract_archive_base_name=TesseractAPI
 top_forge_file=3671753
-top_fabric_file=3699116
  


### PR DESCRIPTION
As per https://github.com/GregTech-Intergalactical/AntimatterAPI/pull/199 I have removed the attempt to integrate the Fabric port of TheOneProbe.

To keep the GTI build files clean this PR just removes the TOP bits from the Fabric build.